### PR TITLE
優待商品の複数選択・画像表示・選択情報の引き継ぎを追加

### DIFF
--- a/SharePerks/SharePerks.Client/Layout/NavMenu.razor
+++ b/SharePerks/SharePerks.Client/Layout/NavMenu.razor
@@ -4,6 +4,7 @@
 
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+    <MudNavLink Href="items" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Redeem">優待商品選択</MudNavLink>
     <MudNavLink Href="counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
     
     <MudNavLink Href="weather" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Weather</MudNavLink>
@@ -48,4 +49,3 @@
         NavigationManager.LocationChanged -= OnLocationChanged;
     }
 }
-

--- a/SharePerks/SharePerks.Client/Pages/Address.razor
+++ b/SharePerks/SharePerks.Client/Pages/Address.razor
@@ -1,0 +1,69 @@
+﻿@page "/address"
+@using Shareholder.Client.Services
+@inject NavigationManager NavigationManager
+@inject RewardSelectionState SelectionState
+
+<PageTitle>住所等の入力</PageTitle>
+
+<MudText Typo="Typo.h4" GutterBottom="true">住所等の入力</MudText>
+<MudText Typo="Typo.body1" Class="mb-4">
+    送付先情報をご入力ください。
+</MudText>
+
+@if (SelectionState.SelectedItems.Count == 0)
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-4">優待商品が選択されていません。先に商品を選択してください。</MudAlert>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="MoveBack">優待商品選択へ戻る</MudButton>
+}
+else
+{
+    <MudPaper Class="pa-4 mb-6" Elevation="1">
+        <MudText Typo="Typo.h6" Class="mb-2">選択した優待商品</MudText>
+        <MudList Dense="true">
+            @foreach (var item in SelectionState.SelectedItems)
+            {
+                <MudListItem>
+                    <MudListItemText>
+                        @item.ItemName（数量: @item.Quantity / 必要ポイント: @item.RequiredPoints）
+                    </MudListItemText>
+                </MudListItem>
+            }
+        </MudList>
+        <MudText Typo="Typo.body2">合計ポイント: @SelectionState.TotalPoints</MudText>
+    </MudPaper>
+
+    <MudPaper Class="pa-4" Elevation="1">
+        <MudGrid>
+            <MudItem xs="12" sm="6">
+                <MudTextField Label="郵便番号" Placeholder="例: 123-4567" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudTextField Label="電話番号" Placeholder="例: 03-1234-5678" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField Label="住所1（都道府県・市区町村）" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField Label="住所2（丁目・番地）" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField Label="住所3（建物名・部屋番号）" Variant="Variant.Outlined" />
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+}
+
+@if (SelectionState.SelectedItems.Count > 0)
+{
+    <MudStack Direction="Row" Justify="Justify.FlexEnd" Spacing="2" Class="mt-6">
+        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" OnClick="MoveBack">戻る</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary">確認へ進む</MudButton>
+    </MudStack>
+}
+
+@code {
+    private void MoveBack()
+    {
+        NavigationManager.NavigateTo("/items");
+    }
+}

--- a/SharePerks/SharePerks.Client/Pages/Items.razor
+++ b/SharePerks/SharePerks.Client/Pages/Items.razor
@@ -1,0 +1,146 @@
+﻿@page "/items"
+@using System.Net.Http.Json
+@using Shared.Dtos
+@using Shareholder.Client.Services
+@inject NavigationManager NavigationManager
+@inject HttpClient Http
+@inject RewardSelectionState SelectionState
+
+<PageTitle>優待商品選択</PageTitle>
+
+<MudText Typo="Typo.h4" GutterBottom="true">優待商品を選択</MudText>
+<MudText Typo="Typo.body1" Class="mb-4">
+    ご希望の優待商品を選択してください。選択後に住所入力へ進めます。
+</MudText>
+
+@if (isLoading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+}
+else if (!string.IsNullOrWhiteSpace(errorMessage))
+{
+    <MudAlert Severity="Severity.Error">@errorMessage</MudAlert>
+}
+else if (rewardItems.Count == 0)
+{
+    <MudAlert Severity="Severity.Info">現在選択できる優待商品がありません。</MudAlert>
+}
+else
+{
+    <MudGrid>
+        @foreach (var item in rewardItems)
+        {
+            <MudItem xs="12" sm="6" md="4">
+                <MudCard Class="@GetCardClass(item)" Elevation="@(IsSelected(item) ? 6 : 1)">
+                    <MudCardMedia Image="@GetImagePath(item)" Height="180px" />
+                    <MudCardContent>
+                        <MudText Typo="Typo.h6">@item.ItemName</MudText>
+                        <MudText Typo="Typo.body2" Class="mb-2">@item.ItemDescription</MudText>
+                        <MudChip Color="Color.Primary" Variant="Variant.Filled">必要ポイント: @item.RequiredPoints</MudChip>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudNumericField T="int" Label="数量" Min="0" Max="99" Value="@GetQuantity(item)" ValueChanged="value => UpdateQuantity(item, value)" />
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
+        }
+    </MudGrid>
+}
+
+<MudDivider Class="my-6" />
+
+@if (TotalPoints > AvailablePoints)
+{
+    <MudAlert Severity="Severity.Error" Class="mb-3">選択した合計ポイントが使用可能ポイントを超えています。</MudAlert>
+}
+
+<MudStack Direction="Row" Justify="Justify.SpaceBetween" Spacing="2">
+    <MudText Typo="Typo.body2">合計ポイント: @TotalPoints / @AvailablePoints</MudText>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!CanProceed)" OnClick="MoveToAddress">
+        住所等の入力へ進む
+    </MudButton>
+</MudStack>
+
+@code {
+    private readonly List<RewardItemSummaryDto> rewardItems = new();
+    private bool isLoading = true;
+    private string? errorMessage;
+    private readonly Dictionary<int, int> quantityByItemId = new();
+    private const int AvailablePoints = 5000;
+
+    private int TotalPoints => rewardItems.Sum(item => item.RequiredPoints * GetQuantity(item));
+
+    private bool CanProceed => TotalPoints > 0 && TotalPoints <= AvailablePoints;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var items = await Http.GetFromJsonAsync<List<RewardItemSummaryDto>>("api/shareholder/items");
+            if (items is not null)
+            {
+                rewardItems.AddRange(items);
+            }
+        }
+        catch (Exception)
+        {
+            errorMessage = "優待商品の取得に失敗しました。時間をおいて再度お試しください。";
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private bool IsSelected(RewardItemSummaryDto item)
+    {
+        return GetQuantity(item) > 0;
+    }
+
+    private string GetCardClass(RewardItemSummaryDto item)
+    {
+        return IsSelected(item) ? "reward-card selected" : "reward-card";
+    }
+
+    private string GetImagePath(RewardItemSummaryDto item)
+    {
+        return string.IsNullOrWhiteSpace(item.ImagePath) ? "images/reward-placeholder.svg" : item.ImagePath;
+    }
+
+    private int GetQuantity(RewardItemSummaryDto item)
+    {
+        return quantityByItemId.TryGetValue(item.ItemId, out var quantity) ? quantity : 0;
+    }
+
+    private void UpdateQuantity(RewardItemSummaryDto item, int quantity)
+    {
+        if (quantity <= 0)
+        {
+            quantityByItemId.Remove(item.ItemId);
+            return;
+        }
+
+        quantityByItemId[item.ItemId] = quantity;
+    }
+
+    private void MoveToAddress()
+    {
+        if (!CanProceed)
+        {
+            return;
+        }
+
+        var selectedItems = rewardItems
+            .Select(item => new SelectedRewardItem(
+                item.ItemId,
+                item.ItemName,
+                item.ImagePath,
+                item.RequiredPoints,
+                GetQuantity(item)))
+            .Where(item => item.Quantity > 0)
+            .ToList();
+
+        SelectionState.SetSelection(selectedItems);
+        NavigationManager.NavigateTo("/address");
+    }
+}

--- a/SharePerks/SharePerks.Client/Pages/Items.razor.css
+++ b/SharePerks/SharePerks.Client/Pages/Items.razor.css
@@ -1,0 +1,11 @@
+.reward-card {
+    height: 100%;
+}
+
+.reward-card.selected {
+    border: 2px solid var(--mud-palette-primary);
+}
+
+.reward-card .mud-card-actions {
+    justify-content: flex-end;
+}

--- a/SharePerks/SharePerks.Client/Program.cs
+++ b/SharePerks/SharePerks.Client/Program.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
+using Shareholder.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
+builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddMudServices();
+builder.Services.AddScoped<RewardSelectionState>();
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();

--- a/SharePerks/SharePerks.Client/Services/RewardSelectionState.cs
+++ b/SharePerks/SharePerks.Client/Services/RewardSelectionState.cs
@@ -1,0 +1,26 @@
+namespace Shareholder.Client.Services;
+
+public sealed class RewardSelectionState
+{
+    public IReadOnlyList<SelectedRewardItem> SelectedItems { get; private set; } = Array.Empty<SelectedRewardItem>();
+
+    public int TotalPoints => SelectedItems.Sum(item => item.RequiredPoints * item.Quantity);
+
+    public void SetSelection(IEnumerable<SelectedRewardItem> items)
+    {
+        SelectedItems = items.ToList();
+    }
+
+    public void Clear()
+    {
+        SelectedItems = Array.Empty<SelectedRewardItem>();
+    }
+}
+
+public sealed record SelectedRewardItem(
+    int ItemId,
+    string ItemName,
+    string? ImagePath,
+    int RequiredPoints,
+    int Quantity
+);

--- a/SharePerks/SharePerks.Client/Shareholder.Client.csproj
+++ b/SharePerks/SharePerks.Client/Shareholder.Client.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="MudBlazor" Version="8.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/SharePerks/SharePerks.Client/wwwroot/images/reward-placeholder.svg
+++ b/SharePerks/SharePerks.Client/wwwroot/images/reward-placeholder.svg
@@ -1,0 +1,5 @@
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" fill="#f5f5f5" />
+  <rect x="80" y="80" width="480" height="200" rx="16" fill="#e0e0e0" />
+  <text x="320" y="190" font-size="28" text-anchor="middle" fill="#757575" font-family="sans-serif">画像準備中</text>
+</svg>

--- a/SharePerks/SharePerks/Data/ApplicationDbContext.cs
+++ b/SharePerks/SharePerks/Data/ApplicationDbContext.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Shared.Entities;
 
 namespace Shareholder.Data
 {
     public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
     {
+        public DbSet<RewardItem> RewardItems => Set<RewardItem>();
     }
 }

--- a/SharePerks/SharePerks/Data/IUnitOfWork.cs
+++ b/SharePerks/SharePerks/Data/IUnitOfWork.cs
@@ -1,0 +1,9 @@
+using Shareholder.Data.Repositories;
+
+namespace Shareholder.Data;
+
+public interface IUnitOfWork
+{
+    IRewardItemRepository RewardItems { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/SharePerks/SharePerks/Data/Repositories/IRewardItemRepository.cs
+++ b/SharePerks/SharePerks/Data/Repositories/IRewardItemRepository.cs
@@ -1,0 +1,8 @@
+using Shared.Entities;
+
+namespace Shareholder.Data.Repositories;
+
+public interface IRewardItemRepository
+{
+    Task<IReadOnlyList<RewardItem>> ListActiveAsync(CancellationToken cancellationToken = default);
+}

--- a/SharePerks/SharePerks/Data/Repositories/RewardItemRepository.cs
+++ b/SharePerks/SharePerks/Data/Repositories/RewardItemRepository.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Shared.Entities;
+
+namespace Shareholder.Data.Repositories;
+
+public sealed class RewardItemRepository(ApplicationDbContext dbContext) : IRewardItemRepository
+{
+    private readonly ApplicationDbContext dbContext = dbContext;
+
+    public async Task<IReadOnlyList<RewardItem>> ListActiveAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.RewardItems
+            .AsNoTracking()
+            .Where(item => item.IsActive)
+            .OrderBy(item => item.DisplayOrder)
+            .ThenBy(item => item.ItemId)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/SharePerks/SharePerks/Data/UnitOfWork.cs
+++ b/SharePerks/SharePerks/Data/UnitOfWork.cs
@@ -1,0 +1,21 @@
+using Shareholder.Data.Repositories;
+
+namespace Shareholder.Data;
+
+public sealed class UnitOfWork : IUnitOfWork
+{
+    private readonly ApplicationDbContext dbContext;
+
+    public UnitOfWork(ApplicationDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+        RewardItems = new RewardItemRepository(dbContext);
+    }
+
+    public IRewardItemRepository RewardItems { get; }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/SharePerks/SharePerks/Shareholder.csproj
+++ b/SharePerks/SharePerks/Shareholder.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SharePerks.Client\Shareholder.Client.csproj" />
+    <ProjectReference Include="..\..\Shared\Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Shared/Dtos/RewardItemSummaryDto.cs
+++ b/Shared/Dtos/RewardItemSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace Shared.Dtos;
+
+public sealed record RewardItemSummaryDto(
+    int ItemId,
+    string ItemCode,
+    string ItemName,
+    string? ItemDescription,
+    int RequiredPoints,
+    string? ImagePath
+);


### PR DESCRIPTION
### Motivation
- 優待商品をポイント内で複数選択できるようにして、ユーザーが数量を指定して複数アイテムを申し込めるようにするため。 
- 商品の視認性向上のため、画像表示（未設定時はプレースホルダー）をカードに追加するため。 
- 選択内容を住所入力画面へ引き渡し、確認・送付先入力のUXを改善するため。 

### Description
- クライアントに選択状態保持用のサービス `RewardSelectionState` を追加し、DI 登録を `Program.cs` に追加しました（スコープ付きサービス）。
- `Pages/Items.razor` を更新して商品の数量を `MudNumericField` で指定できるようにし、合計ポイント計算・上限チェック（暫定で `AvailablePoints = 5000`）を追加しました。選択済みはカード表示を強調し、画像を `MudCardMedia` で表示します。選択確定時に `RewardSelectionState.SetSelection` を呼んで遷移します。 
- `Pages/Address.razor` を更新して、選択内容がない場合の案内表示と、選択済み商品の一覧および合計ポイント表示を追加しました。選択内容があるときのみ「確認へ進む」ボタンを表示します。 
- プレースホルダー画像 `wwwroot/images/reward-placeholder.svg` を追加し、商品に画像パスがない場合に表示するようにしました。 
- スタイル調整として `Pages/Items.razor.css` を追加し、カードの選択状態とアクション位置を調整しました。 

### Testing
- 自動化されたテストは実行していません（環境に `.NET SDK` が存在しないため `dotnet build` / `dotnet test` を実行できませんでした）。
- ローカルのファイル追加・ビルド前検査としてページ・サービス・画像を作成・コミットし、基本的なファイル整合性を確認しました（ビルド/ブラウズは未実行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697769d267388320b19202317dc3d45b)